### PR TITLE
fix: Fix link to project for freshstart

### DIFF
--- a/src/data/singleProjectData.js
+++ b/src/data/singleProjectData.js
@@ -52,7 +52,7 @@ export const singleProjectData = {
 			{
 				id: 3,
 				title: 'Website',
-				details: 'https://pursuit.org',
+				details: 'https://freshstartonestop.netlify.app',
 			}
 		],
 		ObjectivesHeading: 'Objective',


### PR DESCRIPTION
The link to the project was wrong and needed to be corrected.